### PR TITLE
Add maps visibility to flood-drought and oil-spill

### DIFF
--- a/webpage/css/styles.css
+++ b/webpage/css/styles.css
@@ -235,3 +235,8 @@ width: 100%; padding: 8px 10px; border-radius: 10px; border: 1px solid var(--bor
 .workspace { grid-template-columns: 1fr; }
 .map-canvas { height: 60vh; }
 }
+
+#map {
+  width: 100%;
+  height: 500px;
+}

--- a/webpage/pages/flood-drought.html
+++ b/webpage/pages/flood-drought.html
@@ -53,9 +53,43 @@
 
 <!-- Main: map canvas placeholder -->
 <section class="map-panel">
-<div id="map" class="map-canvas" aria-label="Map">
-<!-- Placeholder drawn by map.js until a real Maps API is integrated -->
-</div>
+<div id="map"></div>
+    <script>
+async function loadGoogleMaps() {
+  try {
+    const response = await fetch("http://127.0.0.1:5000/api/config/maps-key");
+    const data = await response.json();
+    const apiKey = data.googleMapsApiKey;
+
+    if (!apiKey) {
+      throw new Error("Missing Google Maps API key");
+    }
+
+    await new Promise((resolve, reject) => {
+      const script = document.createElement("script");
+      script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&v=weekly&libraries=maps`;
+      script.async = true;
+      script.defer = true;
+      script.onload = resolve;
+      script.onerror = reject;
+      document.head.appendChild(script);
+    });
+
+    const { Map } = await google.maps.importLibrary("maps");
+    const map = new Map(document.getElementById("map"), {
+      center: { lat: 33.749, lng: -84.388 }, 
+      zoom: 8,
+      mapTypeId: "terrain",
+    });
+
+  } catch (error) {
+    console.error("Error initializing Google Maps:", error);
+  }
+}
+
+loadGoogleMaps();
+</script>
+
 </section>
 
 
@@ -75,6 +109,5 @@
 
 
 <script src="../js/map.js" defer></script>
-<script src="../js/pages/floodDrought.js" defer></script>
 </body>
 </html>

--- a/webpage/pages/oil-spill.html
+++ b/webpage/pages/oil-spill.html
@@ -48,8 +48,45 @@
 </aside>
 
 
+<!-- Main: map canvas -->
 <section class="map-panel">
-<div id="map" class="map-canvas" aria-label="Map"></div>
+<div id="map"></div>
+    <script>
+        async function loadGoogleMaps() {
+        try {
+            const response = await fetch("http://127.0.0.1:5000/api/config/maps-key");
+            const data = await response.json();
+            const apiKey = data.googleMapsApiKey;
+
+            if (!apiKey) {
+            throw new Error("Missing Google Maps API key");
+            }
+
+            await new Promise((resolve, reject) => {
+            const script = document.createElement("script");
+            script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&v=weekly&libraries=maps`;
+            script.async = true;
+            script.defer = true;
+            script.onload = resolve;
+            script.onerror = reject;
+            document.head.appendChild(script);
+            });
+
+            const { Map } = await google.maps.importLibrary("maps");
+            const map = new Map(document.getElementById("map"), {
+            center: { lat: 33.749, lng: -84.388 }, 
+            zoom: 8,
+            mapTypeId: "terrain",
+            });
+
+        } catch (error) {
+            console.error("Error initializing Google Maps:", error);
+        }
+        }
+
+        loadGoogleMaps();
+    </script>
+
 </section>
 
 


### PR DESCRIPTION
This commit replaces the placeholders put in place for the Google Maps API with the actual JS component. Because the API key needs to be exposed client-side, we have to request it from the backend. The current solution involves a hard-coded setup for local development, but changes will need to be made regarding how the key is retrieved and how the frontend communicates with the backend for production.